### PR TITLE
fix: prepare configuration for loginservice without b2c

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/innloggingsstatus/config/Environment.kt
+++ b/src/main/kotlin/no/nav/personbruker/innloggingsstatus/config/Environment.kt
@@ -35,7 +35,6 @@ data class Environment(
     val selfIssuedIssuer: String = getEnvVar("SELF_ISSUED_ISSUER"),
     val selfIssuedSecretKey: String = getEnvVar("SELF_ISSUED_SECRET_KEY"),
     val selfIssuedCookieName: String = getEnvVar("SELF_ISSUED_COOKIE_NAME", "innloggingsstatus-token"),
-    val idportenIssuer: String = getEnvVar("IDPORTEN_ISSUER"),
     val idportenAcceptedAudience: String = getEnvVar("IDPORTEN_ACCEPTED_AUDIENCE", "https://nav.no"),
     val idportenWellKnownUrl: String = getEnvVar("IDPORTEN_WELL_KNOWN_URL"),
     val idportenIdentityClaim: String = getEnvVar("IDPORTEN_IDENTITY_CLAIM", "pid")

--- a/src/main/kotlin/no/nav/personbruker/innloggingsstatus/selfissued/SelfIssuedTokenService.kt
+++ b/src/main/kotlin/no/nav/personbruker/innloggingsstatus/selfissued/SelfIssuedTokenService.kt
@@ -26,7 +26,7 @@ class SelfIssuedTokenService(
 
     // exchanges an inbound ID-porten token with a self-issued token containing custom claims based on the input token
     fun exchangeToken(call: ApplicationCall): SelfIssuedTokenResponse {
-        val idportenToken: JwtToken? = oidcTokenValidator.getValidToken(call, environment.idportenIssuer)
+        val idportenToken: JwtToken? = oidcTokenValidator.getValidToken(call, environment.oidcIssuer)
 
         if (idportenToken == null) {
             val description = "Authorization header does not contain a valid ID-porten token."

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -18,11 +18,6 @@ no.nav.security.jwt {
             discoveryurl = ${?LOGINSERVICE_IDPORTEN_DISCOVERY_URL}
             accepted_audience = ${?LOGINSERVICE_IDPORTEN_AUDIENCE}
             cookie_name = selvbetjening-idtoken
-        },
-        {
-            issuer_name = ${?IDPORTEN_ISSUER}
-            discoveryurl = ${?IDPORTEN_WELL_KNOWN_URL}
-            accepted_audience = ${?IDPORTEN_ACCEPTED_AUDIENCE}
             optional_claims = nbf # ID-porten does not include this claim
         }
     ]

--- a/src/test/kotlin/no/nav/personbruker/innloggingsstatus/selfissued/SelfIssuedTokenServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/innloggingsstatus/selfissued/SelfIssuedTokenServiceTest.kt
@@ -73,7 +73,7 @@ class SelfIssuedTokenServiceTest {
         val idportenIssuer = "idporten"
         val idportenIdentityClaim = "pid"
 
-        every { environment.idportenIssuer } returns idportenIssuer
+        every { environment.oidcIssuer } returns idportenIssuer
         every { environment.idportenIdentityClaim } returns idportenIdentityClaim
         every { oidcTokenValidator.getValidToken(call, idportenIssuer) } returns idportenToken
         every { selfIssuedTokenIssuer.issueToken(idportenToken) } returns selfIssuedToken
@@ -90,7 +90,7 @@ class SelfIssuedTokenServiceTest {
     @Test
     fun `should return access denied if attempting to exchange invalid ID-porten token`() {
         val issuer = "idporten"
-        every { environment.idportenIssuer } returns issuer
+        every { environment.oidcIssuer } returns issuer
         every { oidcTokenValidator.getValidToken(call, issuer) } returns null
 
         when (val response = selfIssuedTokenService.exchangeToken(call)) {


### PR DESCRIPTION
Ved overgang i Loginservice fra Azure AD B2C til ID-porten direkte så blir issuerne den samme - så derfor må vi ha samme konfig for dem her i innloggingsstatus. 

Dette er nå rullet ut i dev. PRen fikser problemet i dev der tokens ikke blir validert lenger.
Bør ikke rulles ut i prod før vi har gjort endringen i Loginservice, tenativt 10. mai, ref. https://nav-it.slack.com/archives/C01DE3M9YBV/p1647867506386019

Co-Authored-By: Jan-Kåre Solbakken <jan-kare.solbakken@nav.no>