### PR TITLE
Proxy

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,6 +49,7 @@ dependencies {
     testImplementation(Kluent.kluent)
     testImplementation(Ktor.clientMock)
     testImplementation(Ktor.clientMockJvm)
+    testImplementation(Ktor.testHostJvm)
     testImplementation(Mockk.mockk)
 }
 

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -66,6 +66,7 @@ object Ktor {
     const val jackson = "$groupId:ktor-serialization-jackson:$version"
     const val defaultHeaders = "$groupId:ktor-server-default-headers:$version"
     const val cors = "$groupId:ktor-server-cors:$version"
+    const val testHostJvm = "$groupId:ktor-server-test-host-jvm:$version"
 }
 
 object Logback {

--- a/nais/nais.yaml
+++ b/nais/nais.yaml
@@ -26,6 +26,9 @@ spec:
   {{/each}}
   accessPolicy:
     outbound:
+      rules:
+        - namespace: min-side
+          application: tms-varselbjelle-api
       external:
         - host: {{ pdl-api-host }}
   envFrom:

--- a/src/main/kotlin/no/nav/personbruker/innloggingsstatus/auth/AuthTokenService.kt
+++ b/src/main/kotlin/no/nav/personbruker/innloggingsstatus/auth/AuthTokenService.kt
@@ -35,7 +35,7 @@ class AuthTokenService(
         return getUserInfo(authInfo)
     }
 
-    private fun fetchAndParseAuthInfo(call: ApplicationCall): AuthInfo {
+    fun fetchAndParseAuthInfo(call: ApplicationCall): AuthInfo {
         val oidcToken = getNewestOidcToken(call)
         return AuthInfo(oidcToken)
     }

--- a/src/main/kotlin/no/nav/personbruker/innloggingsstatus/config/ApplicationContext.kt
+++ b/src/main/kotlin/no/nav/personbruker/innloggingsstatus/config/ApplicationContext.kt
@@ -15,6 +15,8 @@ import no.nav.personbruker.innloggingsstatus.selfissued.SelfIssuedTokenIssuer
 import no.nav.personbruker.innloggingsstatus.selfissued.SelfIssuedTokenService
 import no.nav.personbruker.innloggingsstatus.selfissued.SelfIssuedTokenValidator
 import no.nav.personbruker.innloggingsstatus.user.SubjectNameService
+import no.nav.personbruker.innloggingsstatus.varsel.VarselbjelleConsumer
+import no.nav.personbruker.innloggingsstatus.varsel.VarselbjelleTokenFetcher
 import no.nav.tms.token.support.azure.exchange.AzureServiceBuilder
 
 class ApplicationContext(config: ApplicationConfig) {
@@ -44,6 +46,9 @@ class ApplicationContext(config: ApplicationConfig) {
 
     val authTokenService =
         AuthTokenService(oidcValidationService, subjectNameService, selfIssuedTokenService)
+
+    val varselbjelleTokenFetcher = VarselbjelleTokenFetcher(azureService, environment.varselbjelleApiClientId)
+    val varselbjelleConsumer = VarselbjelleConsumer(environment.varselbjelleApiUrl, httpClient, varselbjelleTokenFetcher)
 
     val selfTests = listOf(pdlConsumer)
 }

--- a/src/main/kotlin/no/nav/personbruker/innloggingsstatus/config/Environment.kt
+++ b/src/main/kotlin/no/nav/personbruker/innloggingsstatus/config/Environment.kt
@@ -17,5 +17,7 @@ data class Environment(
     val selfIssuedIssuer: String = getEnvVar("SELF_ISSUED_ISSUER"),
     val selfIssuedSecretKey: String = getEnvVar("SELF_ISSUED_SECRET_KEY"),
     val selfIssuedCookieName: String = getEnvVar("SELF_ISSUED_COOKIE_NAME", "innloggingsstatus-token"),
-    val idportenIdentityClaim: String = getEnvVar("IDPORTEN_IDENTITY_CLAIM", "pid")
+    val idportenIdentityClaim: String = getEnvVar("IDPORTEN_IDENTITY_CLAIM", "pid"),
+    val varselbjelleApiUrl: String = getEnvVar("VARSELBJELLE_API_URL"),
+    val varselbjelleApiClientId: String = getEnvVar("VARSELBJELLE_API_CLIENT_ID")
 )

--- a/src/main/kotlin/no/nav/personbruker/innloggingsstatus/config/bootstrap.kt
+++ b/src/main/kotlin/no/nav/personbruker/innloggingsstatus/config/bootstrap.kt
@@ -15,6 +15,7 @@ import io.ktor.server.plugins.defaultheaders.DefaultHeaders
 import io.ktor.server.routing.routing
 import no.nav.personbruker.innloggingsstatus.auth.authApi
 import no.nav.personbruker.innloggingsstatus.health.healthApi
+import no.nav.personbruker.innloggingsstatus.varsel.varselApi
 
 fun Application.mainModule() {
 
@@ -47,6 +48,7 @@ fun Application.mainModule() {
     routing {
         healthApi(applicationContext.selfTests, applicationContext.appMicrometerRegistry)
         authApi(applicationContext.authTokenService, applicationContext.selfIssuedTokenService)
+        varselApi(applicationContext.authTokenService, applicationContext.varselbjelleConsumer)
     }
 
     configureShutdownHook(applicationContext.httpClient)

--- a/src/main/kotlin/no/nav/personbruker/innloggingsstatus/varsel/VarselbjelleConsumer.kt
+++ b/src/main/kotlin/no/nav/personbruker/innloggingsstatus/varsel/VarselbjelleConsumer.kt
@@ -1,0 +1,64 @@
+package no.nav.personbruker.innloggingsstatus.varsel
+
+import io.ktor.client.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import java.net.URL
+
+class VarselbjelleConsumer(
+    val varselbjelleUrl: String,
+    val httpClient: HttpClient,
+    val tokenFetcher: VarselbjelleTokenFetcher
+) {
+    suspend fun getVarselSummary(ident: String, authLevel: Int): HttpResponse {
+        val accessToken = tokenFetcher.fetchToken()
+
+        return httpClient.request {
+            url("$varselbjelleUrl/varsel/sammendrag")
+            method = HttpMethod.Get
+
+            header("fodselsnummer", ident)
+            header("auth_level", authLevel)
+            header(HttpHeaders.Authorization, "Bearer $accessToken")
+        }
+    }
+
+    suspend fun postErLest(ident: String, varselId: String): HttpResponse {
+        val accessToken = tokenFetcher.fetchToken()
+
+        return httpClient.request {
+            url("$varselbjelleUrl/varsel/erlest/$varselId")
+            method = HttpMethod.Post
+
+            header("fodselsnummer", ident)
+            header(HttpHeaders.Authorization, "Bearer $accessToken")
+        }
+    }
+
+    suspend fun makeGetProxyCall(path: String, ident: String, authLevel: Int): HttpResponse {
+        val accessToken = tokenFetcher.fetchToken()
+
+        return httpClient.request {
+            url("$varselbjelleUrl/$path")
+            method = HttpMethod.Get
+
+            header("fodselsnummer", ident)
+            header("auth_level", authLevel)
+            header(HttpHeaders.Authorization, "Bearer $accessToken")
+        }
+    }
+
+    suspend fun makePostProxyCall(path: String, ident: String, authLevel: Int): HttpResponse {
+        val accessToken = tokenFetcher.fetchToken()
+
+        return httpClient.request {
+            url("$varselbjelleUrl/$path")
+            method = HttpMethod.Post
+
+            header("fodselsnummer", ident)
+            header("auth_level", authLevel)
+            header(HttpHeaders.Authorization, "Bearer $accessToken")
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/personbruker/innloggingsstatus/varsel/VarselbjelleTokenFetcher.kt
+++ b/src/main/kotlin/no/nav/personbruker/innloggingsstatus/varsel/VarselbjelleTokenFetcher.kt
@@ -1,0 +1,12 @@
+package no.nav.personbruker.innloggingsstatus.varsel
+
+import no.nav.tms.token.support.azure.exchange.AzureService
+
+class VarselbjelleTokenFetcher(
+    private val azureService: AzureService,
+    private val varselbjelleClientId: String
+) {
+    suspend fun fetchToken(): String {
+        return azureService.getAccessToken(varselbjelleClientId)
+    }
+}

--- a/src/main/kotlin/no/nav/personbruker/innloggingsstatus/varsel/varselApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/innloggingsstatus/varsel/varselApi.kt
@@ -1,0 +1,62 @@
+package no.nav.personbruker.innloggingsstatus.varsel
+
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import io.ktor.util.pipeline.*
+import no.nav.personbruker.innloggingsstatus.auth.AuthTokenService
+
+fun Route.varselApi(authService: AuthTokenService, varselbjelleConsumer: VarselbjelleConsumer) {
+    get("/rest/varsel/hentsiste") {
+        doIfAuthenticated(authService) { ident, authLevel ->
+            val response = varselbjelleConsumer.getVarselSummary(ident, authLevel)
+
+            call.respond(response.status, response.readBytes())
+        }
+    }
+
+    post("/rest/varsel/erlest/{varselId}") {
+        doIfAuthenticated(authService) { ident, _ ->
+            val varselId = call.parameters["varselId"]?: ""
+
+            val response = varselbjelleConsumer.postErLest(ident, varselId)
+
+            call.respond(response.status, response.readBytes())
+        }
+    }
+
+    get("/varsel/proxy/{path}") {
+        doIfAuthenticated(authService) { ident, authLevel ->
+            val path = call.parameters["path"]?: ""
+
+            val response = varselbjelleConsumer.makeGetProxyCall(path, ident, authLevel)
+
+            call.respond(response.status, response.readBytes())
+        }
+    }
+
+    post("/varsel/proxy/{path}") {
+        doIfAuthenticated(authService) { ident, authLevel ->
+            val path = call.parameters["path"]?: ""
+
+            val response = varselbjelleConsumer.makePostProxyCall(path, ident, authLevel)
+
+            call.respond(response.status, response.readBytes())
+        }
+    }
+}
+
+suspend fun PipelineContext<Unit, ApplicationCall>.doIfAuthenticated(
+    authService: AuthTokenService,
+    block: suspend (String, Int) -> Unit
+) {
+    val authInfo = authService.fetchAndParseAuthInfo(call)
+
+    if (authInfo.authenticated) {
+        block(authInfo.subject!!, authInfo.authLevel!!)
+    } else {
+        call.respond(HttpStatusCode.Unauthorized)
+    }
+}

--- a/src/test/kotlin/no/nav/personbruker/innloggingsstatus/varsel/VarselApiTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/innloggingsstatus/varsel/VarselApiTest.kt
@@ -1,0 +1,191 @@
+package no.nav.personbruker.innloggingsstatus.varsel
+
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import io.ktor.server.testing.*
+import io.ktor.util.*
+import io.mockk.clearMocks
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.personbruker.innloggingsstatus.auth.AuthInfo
+import no.nav.personbruker.innloggingsstatus.auth.AuthTokenService
+import no.nav.personbruker.innloggingsstatus.oidc.OidcTokenInfo
+import org.amshove.kluent.`should be equal to`
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+internal class VarselApiTest {
+
+    private val authService: AuthTokenService = mockk()
+    private val tokenFetcher: VarselbjelleTokenFetcher = mockk()
+
+    private val ident = "123"
+    private val level = 4
+    private val varselbjelleUrl = "http://varselbjelle-api"
+    private val sammendrag = "sammendrag"
+
+    @AfterEach
+    fun cleanup() {
+        clearMocks(authService, tokenFetcher)
+    }
+
+    @Test
+    fun `Henter varselSammendrag fra varselbjelle-api`() = testVarselApi {
+
+
+        every { authService.fetchAndParseAuthInfo(any()) } returns authenticated(ident, level)
+        coEvery { tokenFetcher.fetchToken() } returns "token"
+
+        val result = client.request {
+            url("/rest/varsel/hentsiste")
+            method = HttpMethod.Get
+            header(HttpHeaders.Authorization, "dummy")
+        }
+
+        result.status `should be equal to` HttpStatusCode.OK
+        result.readBytes() shouldBeEqualTo sammendrag.encodeToByteArray()
+    }
+
+    @Test
+    fun `Videresender erlest til varselbjelle-api`() = testVarselApi {
+        every { authService.fetchAndParseAuthInfo(any()) } returns authenticated(ident, level)
+        coEvery { tokenFetcher.fetchToken() } returns "token"
+
+        val id = "654"
+
+        val result = client.request {
+            url("/rest/varsel/erlest/$id")
+            method = HttpMethod.Post
+            header(HttpHeaders.Authorization, "dummy")
+        }
+
+        result.status `should be equal to` HttpStatusCode.OK
+        result.readBytes() shouldBeEqualTo id.encodeToByteArray()
+    }
+
+    @Test
+    fun `Proxyer get-kall til vilkårlige endepunkt hos varselbjelle-api`() = testVarselApi {
+        every { authService.fetchAndParseAuthInfo(any()) } returns authenticated(ident, level)
+        coEvery { tokenFetcher.fetchToken() } returns "token"
+
+        val result = client.request {
+            url("/varsel/proxy/annet/endepunkt")
+            method = HttpMethod.Get
+            header(HttpHeaders.Authorization, "dummy")
+        }
+
+        result.status `should be equal to` HttpStatusCode.OK
+    }
+
+    @Test
+    fun `Svarer med 401 hvis bruker ikke er autentisert`() = testVarselApi {
+        every { authService.fetchAndParseAuthInfo(any()) } returns unauthenticated()
+
+        client.request {
+            url("/rest/varsel/hentsiste")
+            method = HttpMethod.Get
+            header(HttpHeaders.Authorization, "dummy")
+        }.status shouldBeEqualTo HttpStatusCode.Unauthorized
+
+        client.request {
+            url("/rest/varsel/erlest/123")
+            method = HttpMethod.Post
+            header(HttpHeaders.Authorization, "dummy")
+        }.status shouldBeEqualTo HttpStatusCode.Unauthorized
+
+        client.request {
+            url("/varsel/proxy/annet/endepunkt")
+            method = HttpMethod.Get
+            header(HttpHeaders.Authorization, "dummy")
+        }.status shouldBeEqualTo HttpStatusCode.Unauthorized
+
+        client.request {
+            url("/varsel/proxy/annet/endepunkt")
+            method = HttpMethod.Post
+            header(HttpHeaders.Authorization, "dummy")
+        }.status shouldBeEqualTo HttpStatusCode.Unauthorized
+    }
+
+    @Test
+    fun `Proxyer post-kall til vilkårlige endepunkt hos varselbjelle-api`() = testVarselApi {
+        every { authService.fetchAndParseAuthInfo(any()) } returns authenticated(ident, level)
+        coEvery { tokenFetcher.fetchToken() } returns "token"
+
+        val result = client.request {
+            url("/varsel/proxy/annet/endepunkt")
+            method = HttpMethod.Post
+            header(HttpHeaders.Authorization, "dummy")
+        }
+
+        result.status `should be equal to` HttpStatusCode.OK
+    }
+
+    @Test
+    fun `Svarer med 400 hvis path ikke fantes hos varselbjelle-api`() = testVarselApi {
+        every { authService.fetchAndParseAuthInfo(any()) } returns authenticated(ident, level)
+        coEvery { tokenFetcher.fetchToken() } returns "token"
+
+        val result = client.request {
+            url("/varsel/proxy/finnes/ikke")
+            method = HttpMethod.Post
+            header(HttpHeaders.Authorization, "dummy")
+        }
+
+        result.status `should be equal to` HttpStatusCode.BadRequest
+    }
+
+    private fun authenticated(ident: String, level: Int): AuthInfo {
+        val tokenInfo = OidcTokenInfo(
+            subject = ident,
+            authLevel = level,
+            issueTime = LocalDateTime.now(),
+            expiryTime = LocalDateTime.now().plusHours(1)
+        )
+
+        return AuthInfo(tokenInfo)
+    }
+
+    private fun unauthenticated() = AuthInfo(null)
+
+    @KtorDsl
+    private fun testVarselApi(block: suspend ApplicationTestBuilder.(VarselbjelleConsumer) -> Unit) = testApplication {
+        val varselbjelleConsumer = VarselbjelleConsumer(varselbjelleUrl, client, tokenFetcher)
+
+        application {
+            routing {
+                varselApi(authService, varselbjelleConsumer)
+            }
+        }
+
+        externalServices {
+            hosts(varselbjelleUrl) {
+                routing {
+                    get("/varsel/sammendrag") {
+                        call.respond(HttpStatusCode.OK, sammendrag)
+                    }
+
+                    get("/annet/endepunkt") {
+                        call.respond(HttpStatusCode.OK, "ok")
+                    }
+
+                    post("/varsel/erlest/{id}") {
+                        call.respond(HttpStatusCode.OK, call.parameters["id"]?:"")
+                    }
+
+                    post("/annet/endepunkt") {
+                        call.respond(HttpStatusCode.OK, "ok")
+                    }
+                }
+            }
+        }
+
+        this.block(varselbjelleConsumer)
+    }
+}

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -1,0 +1,5 @@
+ktor {
+    application {
+        modules = []
+    }
+}


### PR DESCRIPTION
Legger til 4 proxy-endepunkt mot varselbjelle-api. 
 - 2 går statisk mot tilsvarende endepunkt hos varselbjelle-api
 - 2 er dynamiske proxyer som tillater bruk av nye endepunkt hos varselbjelle-api uten at noe må endres i innloggingsstatus hver gang.

Hensikten med dette er at varselbjella skal fungere uansett hvordan bruker har logget inn, slik som med navn.